### PR TITLE
Add expiration check for anonymous client.

### DIFF
--- a/apigateway/views.py
+++ b/apigateway/views.py
@@ -70,13 +70,13 @@ class BootstrapView(Resource):
                     client, token = extensions.auth_service.bootstrap_anonymous_user()
                     session["oauth_client"] = client.client_id
 
-        # Check if the client_id is valid and that there is no client/user mismatch
-        elif not client_id or (
-            client.user_id != current_user.get_id()
-            and not current_user.is_anonymous_bootstrap_user
-        ):
-            client, token = extensions.auth_service.bootstrap_anonymous_user()
-            session["oauth_client"] = client.client_id
+            # Check if the client_id is valid and that there is no client/user mismatch
+            elif not client_id or (
+                client.user_id != current_user.get_id()
+                and not current_user.is_anonymous_bootstrap_user
+            ):
+                client, token = extensions.auth_service.bootstrap_anonymous_user()
+                session["oauth_client"] = client.client_id
 
         else:
             client, token = extensions.auth_service.bootstrap_user(

--- a/apigateway/views.py
+++ b/apigateway/views.py
@@ -66,14 +66,17 @@ class BootstrapView(Resource):
 
             if client_id:
                 client, token = extensions.auth_service.load_client(client_id)
+                if token.expires_at() < datetime.now().timestamp():
+                    client, token = extensions.auth_service.bootstrap_anonymous_user()
+                    session["oauth_client"] = client.client_id
 
-            # Check if the client_id is valid and that there is no client/user mismatch
-            if not client_id or (
-                client.user_id != current_user.get_id()
-                and not current_user.is_anonymous_bootstrap_user
-            ):
-                client, token = extensions.auth_service.bootstrap_anonymous_user()
-                session["oauth_client"] = client.client_id
+        # Check if the client_id is valid and that there is no client/user mismatch
+        elif not client_id or (
+            client.user_id != current_user.get_id()
+            and not current_user.is_anonymous_bootstrap_user
+        ):
+            client, token = extensions.auth_service.bootstrap_anonymous_user()
+            session["oauth_client"] = client.client_id
 
         else:
             client, token = extensions.auth_service.bootstrap_user(


### PR DESCRIPTION
- Added a check in the `BootstrapView` that checks whether anonymous token is expired and regenerates accordingly.

**Note:** this doesn't currently retain the `client_id`.